### PR TITLE
Now users can have a default group

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,6 +19,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     @user.groups << Group.find(1)
+    @user.default_group = 1
     @user.save 
     session[:user_id] = @user.id
     redirect_to user_path(@user)
@@ -40,6 +41,15 @@ class UsersController < ApplicationController
     session[:user_id] = nil
     flash[:notice] = "Your account has successfully been deleted. Thanks for coming by!"
     redirect_to root_path
+  end
+
+  def set_default_group
+    set_user
+    @user.default_group = params[:group_id]
+    @user.save
+    @group = Group.find(params[:group_id])
+    flash[:notice] = "#{@group.title} is now your default group"
+    redirect_to @group
   end
 
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -56,6 +56,10 @@ class Group < ApplicationRecord
     self.users.count
   end
 
+  def default_group?(user)
+    id == user.default_group
+  end
+
   def admins
     admins_membership = Membership.where(group_id: id, admin: true)
     admins_membership.collect { |membership| membership.user}

--- a/app/views/groups/_group_details.html.erb
+++ b/app/views/groups/_group_details.html.erb
@@ -1,5 +1,15 @@
+<% if @group.default_group?(@user) %>
+<div class="badge">Default Group </div>
+<% elsif @group.is_member?(@user) %>
+<%= link_to "Make Default Group", set_default_group_path(@group) %>
+<% end %>
+
+
+
+
 <h1> <%= @group.title %> </h1>
 <h2> <%= @group.description %> </h2>
+
 <div class="tc pa4">
 <%= image_tag( @group.photo.url(:thumb), 
                 class: 'br-100 pa1 ba b--black-10 h3 w3') %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,3 +1,6 @@
+
+<p><%= flash[:notice] %></p>
+
 <div>
 
 <%= render 'group_details' %>

--- a/app/views/needs/_form.html.erb
+++ b/app/views/needs/_form.html.erb
@@ -8,7 +8,7 @@
   <%= f.label :expiration, "Expiration Date (Optional)" %><br />
   <%= f.date_select :expiration, {order: [:month, :day, :year], prompt: { day: 'Select day', month: 'Select month', year: 'Select year' }, start_year: Date.today.year, end_year: Date.today.year + 3} %><br><br>
 
-  <%= f.collection_check_boxes(:group_ids, @user.groups, :id, :title) %>
+  <%= f.collection_check_boxes(:group_ids, @user.groups, :id, :title,  {:checked => @user.default_group}) %>
 
 
   <%= f.submit %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
 
   get '/users/:id/edit', to: 'users#edit', as: 'edit_user'
   patch '/users/:id', to: 'users#update'
+  get '/users/set_default_group/:group_id', to: 'users#set_default_group', as: 'set_default_group'
 
   delete '/users/:id', to: 'users#destroy'
 

--- a/db/migrate/20170112165440_add_default_group_to_users.rb
+++ b/db/migrate/20170112165440_add_default_group_to_users.rb
@@ -1,0 +1,5 @@
+class AddDefaultGroupToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :default_group, :integer, :default => 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170111195332) do
+ActiveRecord::Schema.define(version: 20170112165440) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,12 +92,13 @@ ActiveRecord::Schema.define(version: 20170111195332) do
     t.text     "bio"
     t.string   "photo"
     t.string   "zipcode"
-    t.datetime "created_at",          null: false
-    t.datetime "updated_at",          null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
     t.string   "avatar_file_name"
     t.string   "avatar_content_type"
     t.integer  "avatar_file_size"
     t.datetime "avatar_updated_at"
+    t.integer  "default_group",       default: 1
   end
 
   add_foreign_key "group_needs", "groups"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,6 +3,8 @@ def birth_humans
   human.name = FFaker::Name.name
   human.email = FFaker::Internet.email
   human.password = 'password'
+  human.groups << Group.find(1)
+  human.default_group = 1
   human.bio = FFaker::HipsterIpsum.paragraph
   human.zipcode = FFaker::AddressUS.zip_code
   human.join_group( random_pluck( Group ) )


### PR DESCRIPTION
## Changes

New column added to `users` table.
New users are automatically added to the 'world' group, and that group is set as their default
Group show page now specifies if it is a member's default group, and, alternatively, lets 'em make it their default group